### PR TITLE
auto update/restore resolv.conf and replace ifconfig with ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,17 +51,16 @@ sudo apt install socat
 Configure to use `vpnkit.exe` as the DNS server. Unless configured otherwise, `vpnkit.exe` will use the Windows host DNS resolver. Specify another DNS server to bypass this.
 
 ```sh
-cat <<EOL
+sudo tee /etc/wsl.conf > /dev/null <<EOL
 [network]
 generateResolvConf = false
-EOL | sudo tee /etc/wsl.conf
+EOL
 ```
 
 ```sh
-sudo unlink /etc/resolv.conf
-cat <<EOL
+sudo tee /etc/resolv.conf > /dev/null <<EOL
 nameserver 192.168.67.1
-EOL | sudo tee /etc/resolv.conf
+EOL
 ```
 
 ### Configure `http_proxy.json` and `gateway_forwards.json`

--- a/README.md
+++ b/README.md
@@ -46,23 +46,6 @@ sudo ln -s /mnt/c/bin/npiperelay.exe /usr/local/bin/npiperelay.exe
 sudo apt install socat
 ```
 
-### Configure WSL Distro
-
-Configure to use `vpnkit.exe` as the DNS server. Unless configured otherwise, `vpnkit.exe` will use the Windows host DNS resolver. Specify another DNS server to bypass this.
-
-```sh
-sudo tee /etc/wsl.conf > /dev/null <<EOL
-[network]
-generateResolvConf = false
-EOL
-```
-
-```sh
-sudo tee /etc/resolv.conf > /dev/null <<EOL
-nameserver 192.168.67.1
-EOL
-```
-
 ### Configure `http_proxy.json` and `gateway_forwards.json`
 
 This step is only necessary for using a HTTP proxy or exposing some service from the Windows host to the WSL2 VM through VPNKit.

--- a/wsl-vpnkit
+++ b/wsl-vpnkit
@@ -3,7 +3,7 @@
 SOCKET_PATH=/var/run/wsl-vpnkit.sock
 PIPE_PATH="\\\\.\\pipe\\wsl-vpnkit"
 
-POWERSHELL_PATH="/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0//powershell.exe"
+POWERSHELL_PATH="/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/powershell.exe"
 
 VPNKIT_PATH="C:/Program Files/Docker/Docker/resources/vpnkit.exe"
 # VPNKIT_HTTP_CONFIG="\$env:APPDATA/Docker/http_proxy.json"
@@ -58,12 +58,13 @@ tap () {
 
 ipconfig () {
     ip a add $VPNKIT_LOWEST_IP/255.255.255.0 dev $TAP_NAME
-    ip link set $TAP_NAME up
+    ip link set dev $TAP_NAME up
     IP_ROUTE=$(ip route | grep default)
     ip route del $IP_ROUTE
     ip route add default via $VPNKIT_GATEWAY_IP dev $TAP_NAME
     RESOLV_CONF=$(cat /etc/resolv.conf)
     echo "nameserver $VPNKIT_GATEWAY_IP" > /etc/resolv.conf
+
 }
 
 close () {
@@ -73,6 +74,11 @@ close () {
     ip route add $IP_ROUTE
     echo "$RESOLV_CONF" > /etc/resolv.conf
 }
+
+if [[ "$EUID" -ne 0 ]]; then 
+    echo "Please run this script as root"
+    exit 1
+fi
 
 relay &
 PID_RELAY=$!

--- a/wsl-vpnkit
+++ b/wsl-vpnkit
@@ -56,7 +56,8 @@ tap () {
 }
 
 ipconfig () {
-    ifconfig $TAP_NAME $VPNKIT_LOWEST_IP netmask 255.255.255.0 up
+    ip a add $VPNKIT_LOWEST_IP/255.255.255.0 dev $TAP_NAME
+    ip link set $TAP_NAME up
     IP_ROUTE=$(ip route | grep default)
     ip route del $IP_ROUTE
     ip route add default via $VPNKIT_GATEWAY_IP dev $TAP_NAME
@@ -65,7 +66,7 @@ ipconfig () {
 close () {
     kill $PID_RELAY $PID_TAP
     "$POWERSHELL_PATH" -Command "Stop-Process -Id $PID_VPNKIT"
-    ifconfig $TAP_NAME down
+    ip link set dev $TAP_NAME down
     ip route add $IP_ROUTE
 }
 

--- a/wsl-vpnkit
+++ b/wsl-vpnkit
@@ -19,6 +19,7 @@ PID_RELAY=
 PID_VPNKIT=
 PID_TAP=
 IP_ROUTE=
+RESOLV_CONF=
 
 relay () {
     socat UNIX-LISTEN:$SOCKET_PATH,fork,umask=007 EXEC:"npiperelay.exe -ep -s ${PIPE_PATH//\\//}",nofork
@@ -61,6 +62,8 @@ ipconfig () {
     IP_ROUTE=$(ip route | grep default)
     ip route del $IP_ROUTE
     ip route add default via $VPNKIT_GATEWAY_IP dev $TAP_NAME
+    RESOLV_CONF=$(cat /etc/resolv.conf)
+    echo "nameserver $VPNKIT_GATEWAY_IP" > /etc/resolv.conf
 }
 
 close () {
@@ -68,6 +71,7 @@ close () {
     "$POWERSHELL_PATH" -Command "Stop-Process -Id $PID_VPNKIT"
     ip link set dev $TAP_NAME down
     ip route add $IP_ROUTE
+    echo "$RESOLV_CONF" > /etc/resolv.conf
 }
 
 relay &


### PR DESCRIPTION
Edited to reflect additional changes:

* automatically update/restore `/etc/resolv.conf`
* remove section about manually setting `/etc/resolv.conf` from readme
* replace usage of `ifconfig` with `ip`
* added a check for running as root

Original:

- Correct tee command in README.md
- Use ip instead of ifconfig which not install by default on many distro