### PR TITLE
use npiperelay path variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ unzip npiperelay_windows_amd64.zip npiperelay.exe
 rm npiperelay_windows_amd64.zip
 mkdir -p /mnt/c/bin
 mv npiperelay.exe /mnt/c/bin/
-sudo ln -s /mnt/c/bin/npiperelay.exe /usr/local/bin/npiperelay.exe
 ```
 
 ### Install `socat`

--- a/wsl-vpnkit
+++ b/wsl-vpnkit
@@ -4,6 +4,7 @@ SOCKET_PATH=/var/run/wsl-vpnkit.sock
 PIPE_PATH="//./pipe/wsl-vpnkit"
 
 VPNKIT_PATH=${VPNKIT_PATH:-/mnt/c/bin/wsl-vpnkit.exe}
+VPNKIT_NPIPERELAY_PATH=${VPNKIT_NPIPERELAY_PATH:-/mnt/c/bin/npiperelay.exe}
 # VPNKIT_HTTP_CONFIG="C:/Users/user/AppData/Roaming/Docker/http_proxy.json"
 # VPNKIT_GATEWAY_FORWARD_CONFIG="C:/Users/user/AppData/Roaming/Docker/gateway_forwards.json"
 VPNKIT_BACKLOG="32"
@@ -18,7 +19,7 @@ IP_ROUTE=
 RESOLV_CONF=
 
 relay () {
-    socat UNIX-LISTEN:$SOCKET_PATH,fork,umask=007 EXEC:"npiperelay.exe -ep -s $PIPE_PATH",nofork
+    socat UNIX-LISTEN:$SOCKET_PATH,fork,umask=007 EXEC:"$VPNKIT_NPIPERELAY_PATH -ep -s $PIPE_PATH",nofork
 }
 
 vpnkit () {


### PR DESCRIPTION
Make reference to vpnkit.exe and npiperelay.exe consistent.

Existing version
- Assumes `npiperelay.exe` is in `$PATH` of the wsl distro, and describes in readme how to achieve this by creating a symlink in `/usr/local/bin` back to it in `C:\bin\` on host (via the automount `/mnt/c`).
- Assumes `wsl-vpnkit.exe` is in `C:\bin\` on host and references it via variable in the script (via the automount `/mnt/c`).

From my understanding there is no real reason for these to be handled differently?

This PR makes the handling of npiperelay same as vpnkit, which means:
- Don't need the symlink to npiperelay anymore.
- Can still choose to make a symlink to npiperelay, and even vpnkit, in `/usr/local/bin` and start the script like this:
`VPNKIT_PATH=wsl-vpnkit.exe VPNKIT_NPIPERELAY_PATH=npiperelay.exe ./wsl-vpnkit`.

Default is, as before, to have both executables in the host filesystem, at location `C:\bin`. But, one could argue that it would make sense to copy them both into the wsl filesystem instead, to make it "standalone" and not have the reference back to a location in the host filesystem. If there is a new version one would then have to copy it into each WSL distro, as opposed to just updating a single shared location on host. Haven't decided yet, how I want to do it myself... (By the way, newer versions of WSL seems to introduce more possibilites with easy mounting of virtual disks that can be shared between distros etc.)

Somewhat related to comment: https://github.com/sakai135/wsl-vpnkit/pull/15#issuecomment-829037961