### PR TITLE
Wait for daemon start

### DIFF
--- a/distro/wsl-vpnkit.service
+++ b/distro/wsl-vpnkit.service
@@ -19,7 +19,9 @@ start() {
                 --stdout $LOG_PATH \
                 --stderr $LOG_PATH \
                 --exec wsl-vpnkit \
-                --start
+                --start \
+                --verbose \
+                --wait 2000
             "
     ret=$?
 }


### PR DESCRIPTION
Add a 2000 milliseconds wait for daemon start.

When I launch start-stop-daemon command inside distro, vpnkit processes always start.
But when using wsl-vpnkit.service script, sometimes it not start vpnkit processes, I think it's because wsl.exe close shell before background processes start.

With this pull request, start-stop-daemon always wait 2 seconds for daemon start.