### PR TITLE
add back prompt before exit on startup

### DIFF
--- a/distro/startup.sh
+++ b/distro/startup.sh
@@ -27,6 +27,7 @@ Config for wsl-vpnkit can be edited here. See the wsl-vpnkit script for possible
     $USERPROFILE/wsl-vpnkit/wsl-vpnkit.conf
     wsl.exe -d $WSL_DISTRO_NAME cat /usr/sbin/wsl-vpnkit
 
-
+Press [enter] key to continue...
 "
+read _
 exit 0

--- a/distro/test.sh
+++ b/distro/test.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/sh -e
 
 # run from repo root
 # ./distro/test.sh


### PR DESCRIPTION
* add back prompt before exit on startup script so selecting the distro in Windows Terminal doesn't just close immediately
* set -e on test script to stop on error