### PR TITLE
add safe http transperent proxy configuration

### DIFF
--- a/distro/Dockerfile
+++ b/distro/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir /files && \
     find . -type f -exec sha256sum {} \;
 
 FROM alpine:3.15.0
-RUN apk add --no-cache socat openrc iptables file && \
+RUN apk add --no-cache socat openrc iptables && \
     apk list --installed
 ARG REF=https://example.com/
 ARG VERSION=v0.0.0

--- a/distro/Dockerfile
+++ b/distro/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir /files && \
     find . -type f -exec sha256sum {} \;
 
 FROM alpine:3.15.0
-RUN apk add --no-cache socat openrc iptables && \
+RUN apk add --no-cache socat openrc iptables file && \
     apk list --installed
 ARG REF=https://example.com/
 ARG VERSION=v0.0.0

--- a/wsl-vpnkit
+++ b/wsl-vpnkit
@@ -99,7 +99,7 @@ vpnkit () {
     if [ "$VPNKIT_DEBUG" ]; then
         CMD="$CMD"' --debug'
     fi
-    if [ "$HTTP_PROXY_CONFIG_PATH" ] && [ "$(file -bLkr --mime-type "$HTTP_PROXY_CONFIG_PATH")" = 'application/json' ]; then
+    if [ "$HTTP_PROXY_CONFIG_PATH" ]; then
         CMD="$CMD"' --http "$(wslpath -m ${HTTP_PROXY_CONFIG_PATH})"'
     fi
     eval "$CMD"

--- a/wsl-vpnkit
+++ b/wsl-vpnkit
@@ -3,6 +3,7 @@
 POWERSHELL="$(command -v powershell.exe || echo '/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe')"
 USERPROFILE=$(wslpath "$($POWERSHELL -NoLogo -NoProfile -c 'Write-Host -NoNewline $env:USERPROFILE')")
 CONF_PATH="$USERPROFILE/wsl-vpnkit/wsl-vpnkit.conf"
+HTTP_PROXY_CONFIG_PATH="$USERPROFILE/wsl-vpnkit/http-proxy.json"
 SOCKET_PATH="/var/run/wsl-vpnkit.sock"
 PIPE_PATH="//./pipe/wsl-vpnkit"
 TAP_PID_PATH="/var/run/vpnkit-tap-vsockd.pid"
@@ -97,6 +98,9 @@ vpnkit () {
     '
     if [ "$VPNKIT_DEBUG" ]; then
         CMD="$CMD"' --debug'
+    fi
+    if [ "$HTTP_PROXY_CONFIG_PATH" ] && [ "$(file -bLkr --mime-type "$HTTP_PROXY_CONFIG_PATH")" = 'application/json' ]; then
+        CMD="$CMD"' --http "$(wslpath -m ${HTTP_PROXY_CONFIG_PATH})"'
     fi
     eval "$CMD"
 }


### PR DESCRIPTION
Returned the http transperent proxy setting back. 
By itself, it is safe, but also added a check for the correctness of the format and existence