### PR TITLE
build gvproxy.exe without -s -w to reduce false positive

### DIFF
--- a/distro/Dockerfile
+++ b/distro/Dockerfile
@@ -4,7 +4,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY cmd ./cmd
 COPY pkg ./pkg
-RUN GOOS=windows go build -ldflags '-s -w -H=windowsgui' -o bin/wsl-gvproxy.exe ./cmd/gvproxy && \
+RUN GOOS=windows go build -ldflags '-H=windowsgui' -o bin/wsl-gvproxy.exe ./cmd/gvproxy && \
     GOOS=linux CGO_ENABLED=0 go build -ldflags '-s -w' -o bin/wsl-vm ./cmd/vm && \
     find ./bin -type f -exec sha256sum {} \;
 


### PR DESCRIPTION
Removing `-s -w` and keeping debug info seems to reduce false positives, at least from the VirusTotal results.

Before: https://www.virustotal.com/gui/file/58eb20120c5e9991873b3f0e2896d76826655a9cc6c74481015441f7225ee014
After: https://www.virustotal.com/gui/file/af2ed3076a4afad8f7ee81f2fcddb30f4807badf2e954455f0cfbff03783ee84