### PR TITLE
Improve service init script and logs

### DIFF
--- a/distro/scripts/startup.sh
+++ b/distro/scripts/startup.sh
@@ -8,12 +8,12 @@ touch $LOG_PATH
 
 echo "
 wsl-vpnkit $VERSION
-This distro is only intended for running wsl-vpnkit. 
+This distro is only intended for running wsl-vpnkit.
 
 Run the following commands from Windows or other WSL 2 distros to use.
 
-    wsl.exe -d $WSL_DISTRO_NAME service wsl-vpnkit start
     wsl.exe -d $WSL_DISTRO_NAME service wsl-vpnkit stop
+    wsl.exe -d $WSL_DISTRO_NAME service wsl-vpnkit start
 
 The following file will be copied if it does not already exist.
 
@@ -22,6 +22,10 @@ The following file will be copied if it does not already exist.
 Logs for wsl-vpnkit can be viewed here.
 
     wsl.exe -d $WSL_DISTRO_NAME tail -f $LOG_PATH
+
+To see only the most recent logs
+
+    wsl.exe -d $WSL_DISTRO_NAME sh -c \"tac $LOG_PATH | awk '{print}; /starting wsl-vpnkit/{exit}' | tac\"
 
 Config for wsl-vpnkit can be edited here.
 

--- a/distro/scripts/wsl-vpnkit.service
+++ b/distro/scripts/wsl-vpnkit.service
@@ -1,27 +1,56 @@
 #! /bin/sh
 
-PID_PATH="/var/run/wsl-vpnkit.pid"
-LOG_PATH="/var/log/wsl-vpnkit.log"
+EXECUTABLE="wsl-vpnkit"                 # starting point
+SUB_PROCESS="wsl-vm"                    # forked sub processes
+PID_PATH="/var/run/$EXECUTABLE.pid"
+LOG_PATH="/var/log/$EXECUTABLE.log"
 
 ret=0
 
 start() {
+    [ -n "$DEBUG" ] && set -x
     start-stop-daemon \
         --pidfile $PID_PATH \
         --make-pidfile \
         --background \
         --stdout $LOG_PATH \
         --stderr $LOG_PATH \
-        --exec wsl-vpnkit \
+        --exec $EXECUTABLE \
+        --wait 1000 --progress \
+        ${DEBUG+--verbose} \
         --start
     ret=$?
 }
 
 stop() {
+    if [ -n "$DEBUG" ]; then
+        set -x
+        ps
+        test -f $PID_PATH && cat $PID_PATH
+    fi
     start-stop-daemon \
         --pidfile $PID_PATH \
+        --retry 2 \
+        ${DEBUG+--verbose} \
         --stop
     ret=$?
+    # kill sub processes if still running
+    pgrep $SUB_PROCESS >/dev/null && pkill -9 $SUB_PROCESS
+}
+
+status() {
+    if [ -n "$DEBUG" ]; then
+        set -x
+        ps
+        test -f $PID_PATH && cat $PID_PATH
+    fi
+    test -f $PID_PATH && pgrep -P $(cat $PID_PATH) &>/dev/null
+    ret=$?
+    if [ $ret = 0 ]; then
+        echo Service $EXECUTABLE is running
+    else
+        echo Service $EXECUTABLE is not running
+    fi
 }
 
 case "$1" in
@@ -31,8 +60,11 @@ case "$1" in
     stop)
         stop
         ;;
+    status)
+        status
+        ;;
     *)
-        echo "Usage: wsl-vpnkit {start|stop}"
+        echo "Usage: $EXECUTABLE {start|stop|status}"
         exit 1
 esac
 

--- a/distro/test.sh
+++ b/distro/test.sh
@@ -7,13 +7,43 @@ USERPROFILE="$(powershell.exe -c 'Write-Host -NoNewline $env:USERPROFILE')"
 DUMP=wsl-vpnkit.tar.gz
 TAG_NAME=wslvpnkit
 
+# build
 docker build -t $TAG_NAME -f ./distro/Dockerfile .
 CONTAINER_ID=$(docker create $TAG_NAME)
 docker export $CONTAINER_ID | gzip > $DUMP
 docker container rm $CONTAINER_ID
 ls -la $DUMP
 
+# reinstall
 wsl.exe --unregister wsl-vpnkit || :
 wsl.exe --import wsl-vpnkit "$USERPROFILE\\wsl-vpnkit" $DUMP --version 2
 rm $DUMP
-wsl.exe -d wsl-vpnkit
+
+# tests
+(
+  # start service
+  set -x
+  wsl.exe -d wsl-vpnkit service wsl-vpnkit start
+  output=$(wsl.exe -d wsl-vpnkit DEBUG=1 service wsl-vpnkit status)
+  echo "$output" | grep "Service wsl-vpnkit is running"
+
+  # check latest log
+  sleep 5
+  output=$(wsl.exe -d wsl-vpnkit sh -c "tac /var/log/wsl-vpnkit.log | awk '{print}; /starting wsl-vpnkit/{exit}' | tac")
+
+  # check for working ping
+  echo "$output" | grep "ping success"
+
+  # check for working dns
+  echo "$output" | grep "nslookup success"
+
+  # stop service
+  wsl.exe -d wsl-vpnkit DEBUG=1 service wsl-vpnkit stop
+  output=$(wsl.exe -d wsl-vpnkit DEBUG=1 service wsl-vpnkit status)||true
+  echo "$output" | grep "Service wsl-vpnkit is not running"
+
+  # check welcome screen
+  wsl.exe -d wsl-vpnkit sh -c 'echo 1 | source /etc/profile'
+)
+
+echo "$0 Finished"


### PR DESCRIPTION
- Fixed init service script to allow proper 'start' and 'stop' actions consistently. I kept struggling that service start only worked after killing the distro because sometimes it didn't start/stop properly leaving processes running and without pid file
- Added service 'status' action
- Added additional service debug by setting environment variable DEBUG, ie: wsl.exe -d wsl-vpnkit DEBUG=1 service wsl-vpnkit stop
- Changed order in startup welcome screen having stop followed by start, this makes it easier for users to just copy/paste from welcome screen to have service running
- Added log check command to see only the latest service execution logs