### PR TITLE
Change run location for the wsl-gvproxy to the Program Files dir

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,5 +16,5 @@ ls -la $DUMP
 
 # reinstall
 wsl.exe --unregister wsl-vpnkit || :
-wsl.exe --import wsl-vpnkit "$USERPROFILE\\wsl-vpnkit" $DUMP --version 2
+wsl.exe --import wsl-vpnkit "C:\Program Files\wsl-vpnkit" $DUMP --version 2
 rm $DUMP

--- a/wsl-vpnkit
+++ b/wsl-vpnkit
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 CMDSHELL="$(command -v cmd.exe || echo '/mnt/c/Windows/system32/cmd.exe')"
-USERPROFILE=$(wslpath "$($CMDSHELL /d /v:off /c 'echo | set /p t=%USERPROFILE%' 2>/dev/null)")
+USERPROFILE=$(wslpath "C:\Program Files")
 WSL2_GATEWAY_IP="$(cat /etc/resolv.conf | awk '/^nameserver/ {print $2}')"
 WSL2_VM_IP="$(ifconfig eth0 | awk '/inet /{print substr($2, 6)}')"
 WSL2_TAP_NAME=eth0


### PR DESCRIPTION
Hello!

No idea if this is appreciated, but in my usecase, the corporate policy is that no executable is allowed to run outside the Program Files directory (anti ransomware policy). 

This causes issues with the wsl-gvproxy which is located at the $USERPROFILE. 

This PR changes the location of the wsl-gvproxy to the Program Files directory. It's certified ✨"Works On My Machine Approved"✨, but I couldn't see tests to confirm my suspicions that this works on a broader scale, nor if this is a problem more users run into.

Let me know if this is something you want to support, and if so; if it requires more code changes!