### PR TITLE
remove wait on service start

### DIFF
--- a/distro/scripts/wsl-vpnkit.service
+++ b/distro/scripts/wsl-vpnkit.service
@@ -24,7 +24,6 @@ start() {
         --stdout $LOG_PATH \
         --stderr $LOG_PATH \
         --exec $EXECUTABLE \
-        --wait 1000 --progress \
         ${DEBUG+--verbose} \
         --start
     ret=$?


### PR DESCRIPTION
The wait seems to cause the process to immediately exit. This should resolve #165.