### PR TITLE
Use --ifstopped flag to start the service conditionally

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Start `wsl-vpnkit` from your other WSL 2 distros. Add the command to your `.prof
 wsl.exe -d wsl-vpnkit --cd /app service wsl-vpnkit start
 ```
 
-You can also check service status to start service only if needed.
+You can also conditionally start the service if its stopped.
 
 ```sh
 wsl.exe -d wsl-vpnkit --cd /app service wsl-vpnkit --ifstopped wsl-vpnkit start

--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ wsl.exe -d wsl-vpnkit --cd /app service wsl-vpnkit start
 You can also check service status to start service only if needed.
 
 ```sh
-wsl.exe -d wsl-vpnkit --cd /app service wsl-vpnkit status >/dev/null || \
-wsl.exe -d wsl-vpnkit --cd /app service wsl-vpnkit start
+wsl.exe -d wsl-vpnkit --cd /app service wsl-vpnkit --ifstopped --verbose wsl-vpnkit start
 ```
 
 ### Notes

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ wsl.exe -d wsl-vpnkit --cd /app service wsl-vpnkit start
 You can also check service status to start service only if needed.
 
 ```sh
-wsl.exe -d wsl-vpnkit --cd /app service wsl-vpnkit --ifstopped --verbose wsl-vpnkit start
+wsl.exe -d wsl-vpnkit --cd /app service wsl-vpnkit --ifstopped wsl-vpnkit start
 ```
 
 ### Notes


### PR DESCRIPTION
The `rc-service` provides some nice flags which simplifies the startup of the service in case it's already started.

See rc-service doc:
```
Usage: rc-service [options] [-i] <service> <cmd>...
   or: rc-service [options] -e <service>
   or: rc-service [options] -l
   or: rc-service [options] -r <service>

Options: [ cdDe:ilr:INsSZChqVv ]
  -d, --debug                       set xtrace when running the command
  -D, --nodeps                      ignore dependencies
  -e, --exists <arg>                tests if the service exists or not
  -c, --ifcrashed                   if the service is crashed run the command
  -i, --ifexists                    if the service exists run the command
  -I, --ifinactive                  if the service is inactive run the command
  -N, --ifnotstarted                if the service is not started run the command
  -s, --ifstarted                   if the service is started run the command
  -S, --ifstopped                   if the service is stopped run the command
  -l, --list                        list all available services
  -r, --resolve <arg>               resolve the service name to an init script
  -Z, --dry-run                     dry run (show what would happen)
  -h, --help                        Display this help output
  -C, --nocolor                     Disable color output
  -V, --version                     Display software version
  -v, --verbose                     Run verbosely
  -q, --quiet                       Run quietly (repeat to suppress errors)
```