### PR TITLE
Update version in README to v0.4.1 as v0.4.x doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,12 +130,14 @@ On older WSL versions where `/mnt/wsl/resolv.conf` is not available, `wsl-vpnkit
 `wsl-vpnkit` requires that the WSL 2 distro be able to run Windows executables. This [`interop` setting](https://learn.microsoft.com/en-us/windows/wsl/wsl-config#interop-settings) is enabled by default in WSL 2 and in the `wsl-vpnkit` distro.
 
 Security configurations on the Windows host may only permit running executables in certain directories. You can copy `wsl-gvproxy.exe` to an appropriate location and use the `GVPROXY_PATH` environment variable to specify the location.
+`GVPROXY_PATH` must point to a /mnt folder for wsl-gvproxy.exe to work!
 
 ```sh
 # enable [automount] in wsl.conf for wsl-vpnkit distro
+# Please be sure the [automount] section exists
 wsl.exe -d wsl-vpnkit --cd /app sed -i -- "s/enabled=false/enabled=true/" /etc/wsl.conf
 
-# set GVPROXY_PATH when running wsl-vpnkit
+# set GVPROXY_PATH when running wsl-vpnkit to a /mnt directory (it must reside on windows host filesystem)
 wsl.exe -d wsl-vpnkit --cd /app GVPROXY_PATH=/mnt/c/path/wsl-gvproxy.exe wsl-vpnkit
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The `wsl-vpnkit` script can be used as a normal script in your existing distro. 
 sudo apt-get install iproute2 iptables iputils-ping dnsutils wget
 
 # download wsl-vpnkit and unpack
-VERSION=v0.4.x
+VERSION=v0.4.1
 wget https://github.com/sakai135/wsl-vpnkit/releases/download/$VERSION/wsl-vpnkit.tar.gz
 tar --strip-components=1 -xf wsl-vpnkit.tar.gz \
     app/wsl-vpnkit \

--- a/wsl-vpnkit.service
+++ b/wsl-vpnkit.service
@@ -4,13 +4,16 @@ After=network.target
 
 [Service]
 # for wsl-vpnkit setup as a distro
-ExecStart=/mnt/c/Windows/system32/wsl.exe -d wsl-vpnkit --cd /app wsl-vpnkit
+# No longer supported in 0.4.1
+# ExecStart=/mnt/c/Windows/system32/wsl.exe -d wsl-vpnkit --cd /app wsl-vpnkit
 
 # for wsl-vpnkit setup as a standalone script
-#ExecStart=/full/path/to/wsl-vpnkit
-#Environment=VMEXEC_PATH=/full/path/to/wsl-vm GVPROXY_PATH=/full/path/to/wsl-gvproxy.exe
+# GVPROXY_PATH must point to /mnt directory to work!!!
+ExecStart=/home/hosermage/wsl-vpnkit/wsl-vpnkit
+Environment=VMEXEC_PATH=/home/hosermage/wsl-vpnkit/wsl-vm GVPROXY_PATH=/mnt/c/bin/wsl-vpnkit/wsl-gvproxy.exe
 
 Restart=always
+RestartSec=5
 KillMode=mixed
 
 [Install]


### PR DESCRIPTION
Get the following if following readme:
(.env) hosermage@hosermage-x1:~/wsl-vpnkit$ VERSION=v0.4.x
(.env) hosermage@hosermage-x1:~/wsl-vpnkit$ wget https://github.com/sakai135/wsl-vpnkit/releases/download/$VERSION/wsl-vpnkit.tar.gz
--2023-11-24 22:13:43--  https://github.com/sakai135/wsl-vpnkit/releases/download/v0.4.x/wsl-vpnkit.tar.gz
Resolving github.com (github.com)... 20.205.243.166
Connecting to github.com (github.com)|20.205.243.166|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2023-11-24 22:13:44 ERROR 404: Not Found.