### PR TITLE
Bump gvisor-tap-vsock to v0.7.3

### DIFF
--- a/.github/workflows/distro.yml
+++ b/.github/workflows/distro.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       checks: write
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Build
       run: |
@@ -24,6 +24,7 @@ jobs:
     - uses: anchore/scan-action@v3
       with:
         image: ${{ env.TAG_NAME }}
+        severity-cutoff: high
 
     - name: Package
       run: |
@@ -33,7 +34,7 @@ jobs:
         ls -la wsl-vpnkit.tar.gz
 
     - name: Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: wsl-vpnkit
         path: |

--- a/distro/alpine.dockerfile
+++ b/distro/alpine.dockerfile
@@ -1,18 +1,18 @@
-FROM docker.io/library/alpine:3.17.2 as gvisor-tap-vsock
+FROM docker.io/library/alpine:3.20.0 as gvisor-tap-vsock
 WORKDIR /app/bin
-RUN wget https://github.com/containers/gvisor-tap-vsock/releases/download/v0.6.1/gvproxy-windows.exe && \
-    wget https://github.com/containers/gvisor-tap-vsock/releases/download/v0.6.1/vm && \
-    chmod +x ./gvproxy-windows.exe ./vm
+RUN wget https://github.com/containers/gvisor-tap-vsock/releases/download/v0.7.3/gvproxy-windows.exe && \
+    wget https://github.com/containers/gvisor-tap-vsock/releases/download/v0.7.3/gvforwarder && \
+    chmod +x ./gvproxy-windows.exe ./gvforwarder
 RUN find . -type f -exec sha256sum {} \;
 
-FROM docker.io/library/alpine:3.17.2
+FROM docker.io/library/alpine:3.20.0
 RUN apk update && \
     apk upgrade && \
     apk add iproute2 iptables && \
     apk list --installed && \
     rm -rf /var/cache/apk/*
 WORKDIR /app
-COPY --from=gvisor-tap-vsock /app/bin/vm ./wsl-vm
+COPY --from=gvisor-tap-vsock /app/bin/gvforwarder ./wsl-gvforwarder
 COPY --from=gvisor-tap-vsock /app/bin/gvproxy-windows.exe ./wsl-gvproxy.exe
 COPY ./wsl-vpnkit ./wsl-vpnkit.service ./
 COPY ./distro/wsl.conf /etc/wsl.conf

--- a/distro/fedora.dockerfile
+++ b/distro/fedora.dockerfile
@@ -1,8 +1,8 @@
-FROM docker.io/library/alpine:3.17.2 as gvisor-tap-vsock
+FROM docker.io/library/alpine:3.20.0 as gvisor-tap-vsock
 WORKDIR /app/bin
-RUN wget https://github.com/containers/gvisor-tap-vsock/releases/download/v0.6.1/gvproxy-windows.exe && \
-    wget https://github.com/containers/gvisor-tap-vsock/releases/download/v0.6.1/vm && \
-    chmod +x ./gvproxy-windows.exe ./vm
+RUN wget https://github.com/containers/gvisor-tap-vsock/releases/download/v0.7.3/gvproxy-windows.exe && \
+    wget https://github.com/containers/gvisor-tap-vsock/releases/download/v0.7.3/gvforwarder && \
+    chmod +x ./gvproxy-windows.exe ./gvforwarder
 RUN find . -type f -exec sha256sum {} \;
 
 FROM docker.io/library/fedora:37
@@ -10,7 +10,7 @@ RUN dnf upgrade -y && \
     dnf install -y iproute iptables-legacy iputils bind-utils wget && \
     dnf clean all
 WORKDIR /app
-COPY --from=gvisor-tap-vsock /app/bin/vm ./wsl-vm
+COPY --from=gvisor-tap-vsock /app/bin/gvforwarder ./wsl-gvforwarder
 COPY --from=gvisor-tap-vsock /app/bin/gvproxy-windows.exe ./wsl-gvproxy.exe
 COPY ./wsl-vpnkit ./wsl-vpnkit.service ./
 COPY ./distro/wsl.conf /etc/wsl.conf

--- a/distro/ubuntu.dockerfile
+++ b/distro/ubuntu.dockerfile
@@ -1,8 +1,8 @@
-FROM docker.io/library/alpine:3.17.2 as gvisor-tap-vsock
+FROM docker.io/library/alpine:3.20.0 as gvisor-tap-vsock
 WORKDIR /app/bin
-RUN wget https://github.com/containers/gvisor-tap-vsock/releases/download/v0.6.1/gvproxy-windows.exe && \
-    wget https://github.com/containers/gvisor-tap-vsock/releases/download/v0.6.1/vm && \
-    chmod +x ./gvproxy-windows.exe ./vm
+RUN wget https://github.com/containers/gvisor-tap-vsock/releases/download/v0.7.3/gvproxy-windows.exe && \
+    wget https://github.com/containers/gvisor-tap-vsock/releases/download/v0.7.3/gvforwarder && \
+    chmod +x ./gvproxy-windows.exe ./gvforwarder
 RUN find . -type f -exec sha256sum {} \;
 
 FROM docker.io/library/ubuntu:22.04
@@ -11,7 +11,7 @@ RUN apt-get update && \
     apt-get install -y iproute2 iptables iputils-ping dnsutils wget && \
     apt-get clean
 WORKDIR /app
-COPY --from=gvisor-tap-vsock /app/bin/vm ./wsl-vm
+COPY --from=gvisor-tap-vsock /app/bin/gvforwarder ./wsl-gvforwarder
 COPY --from=gvisor-tap-vsock /app/bin/gvproxy-windows.exe ./wsl-gvproxy.exe
 COPY ./wsl-vpnkit ./wsl-vpnkit.service ./
 COPY ./distro/wsl.conf /etc/wsl.conf

--- a/wsl-vpnkit
+++ b/wsl-vpnkit
@@ -9,7 +9,7 @@ VPNKIT_LOCAL_IP=${VPNKIT_LOCAL_IP:-192.168.127.2}
 TAP_MAC_ADDR=${TAP_MAC_ADDR:-5a:94:ef:e4:0c:ee}
 
 # overrideable with env
-VMEXEC_PATH=${VMEXEC_PATH:-/app/wsl-vm}
+VMEXEC_PATH=${VMEXEC_PATH:-/app/wsl-gvforwarder}
 GVPROXY_PATH=${GVPROXY_PATH:-/app/wsl-gvproxy.exe}
 TAP_NAME=${TAP_NAME:-wsltap}
 CHECK_HOST=${CHECK_HOST:-example.com}

--- a/wsl-vpnkit.service
+++ b/wsl-vpnkit.service
@@ -8,7 +8,7 @@ ExecStart=/mnt/c/Windows/system32/wsl.exe -d wsl-vpnkit --cd /app wsl-vpnkit
 
 # for wsl-vpnkit setup as a standalone script
 #ExecStart=/full/path/to/wsl-vpnkit
-#Environment=VMEXEC_PATH=/full/path/to/wsl-vm GVPROXY_PATH=/full/path/to/wsl-gvproxy.exe
+#Environment=VMEXEC_PATH=/full/path/to/wsl-gvforwarder GVPROXY_PATH=/full/path/to/wsl-gvproxy.exe
 
 Restart=always
 KillMode=mixed


### PR DESCRIPTION
- Bump gvisor-tap-vsock to v0.7.3 (DNS support for CNAME, MX, SRV and TXT records): solves #231
- Bump alpine version of docker image
- Bump Github action versions
- Set `severity-cutoff: high` due to unpatched CVEs on Alpine