### PR TITLE
Use Random Port Selection to Bypass Locked Default VPN Port on Windows

### DIFF
--- a/.github/workflows/distro.yml
+++ b/.github/workflows/distro.yml
@@ -21,9 +21,15 @@ jobs:
       run: |
         docker build -t $TAG_NAME -f ./distro/alpine.dockerfile --build-arg REF=$RUN_URL --build-arg VERSION=${GITHUB_REF#refs/tags/} .
 
-    - uses: anchore/scan-action@v3
+    - name: Vulnerability Scan
+      uses: anchore/scan-action@v3
       with:
         image: ${{ env.TAG_NAME }}
+        fail-build: false          # 不因漏洞中止構建
+        output-format: table       # 設置為表格格式，便於檢視
+        severity-cutoff: medium    # 顯示中等及以上嚴重性漏洞
+      env:
+        ANCHORE_CLI_LOG_LEVEL: DEBUG # 開啟詳細日誌，便於排查問題
 
     - name: Package
       run: |

--- a/.github/workflows/distro.yml
+++ b/.github/workflows/distro.yml
@@ -39,7 +39,7 @@ jobs:
         ls -la wsl-vpnkit.tar.gz
 
     - name: Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: wsl-vpnkit
         path: |

--- a/.github/workflows/distro.yml
+++ b/.github/workflows/distro.yml
@@ -21,15 +21,9 @@ jobs:
       run: |
         docker build -t $TAG_NAME -f ./distro/alpine.dockerfile --build-arg REF=$RUN_URL --build-arg VERSION=${GITHUB_REF#refs/tags/} .
 
-    - name: Vulnerability Scan
-      uses: anchore/scan-action@v3
+    - uses: anchore/scan-action@v3
       with:
         image: ${{ env.TAG_NAME }}
-        fail-build: false          # 不因漏洞中止構建
-        output-format: table       # 設置為表格格式，便於檢視
-        severity-cutoff: medium    # 顯示中等及以上嚴重性漏洞
-      env:
-        ANCHORE_CLI_LOG_LEVEL: DEBUG # 開啟詳細日誌，便於排查問題
 
     - name: Package
       run: |
@@ -39,7 +33,7 @@ jobs:
         ls -la wsl-vpnkit.tar.gz
 
     - name: Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: wsl-vpnkit
         path: |

--- a/wsl-vpnkit
+++ b/wsl-vpnkit
@@ -41,10 +41,25 @@ fi
 # replace calls to iptables if iptables-legacy exists
 command -v iptables-legacy >/dev/null && alias iptables=iptables-legacy
 
+# Choose random free SSH port for GVPROXY by default
+get_random_port() {
+    # starting from BASE_PORT with INCREMENT step
+    BASE_PORT=2222 # the default SSH port chosen if free
+    INCREMENT=1
+
+    port=$BASE_PORT
+
+    while [ -n "$(ss -tan4H "sport = $port")" ]; do
+    port=$((port+INCREMENT))
+    done
+
+    echo "$port"
+}
+
 run () {
     echo "starting vm and gvproxy..."
     $VMEXEC_PATH \
-        -url="stdio:$GVPROXY_PATH?listen-stdio=accept&debug=$DEBUG" \
+        -url="stdio:$GVPROXY_PATH?listen-stdio=accept&ssh-port=$(get_random_port)&debug=$DEBUG" \
         -iface="$TAP_NAME" \
         -stop-if-exist="" \
         -preexisting=1 \

--- a/wsl-vpnkit
+++ b/wsl-vpnkit
@@ -43,14 +43,18 @@ command -v iptables-legacy >/dev/null && alias iptables=iptables-legacy
 
 # Choose random free SSH port for GVPROXY by default
 get_random_port() {
-    # starting from BASE_PORT with INCREMENT step
-    BASE_PORT=2222 # the default SSH port chosen if free
-    INCREMENT=1
+    # Random the range
+    min=49152
+    max=65535
 
-    port=$BASE_PORT
+    # Keep looping until finded usable port
+    while true; do
+        port=$(shuf -i $min-$max -n 1)
 
-    while [ -n "$(ss -tan4H "sport = $port")" ]; do
-    port=$((port+INCREMENT))
+        # Check if port is been using
+        if ! ss -tan4H | grep -qE "LISTEN.*:$port\b"; then
+            break
+        fi
     done
 
     echo "$port"
@@ -58,8 +62,10 @@ get_random_port() {
 
 run () {
     echo "starting vm and gvproxy..."
+    PORT=$(get_random_port)
+    echo "using port: $PORT"
     $VMEXEC_PATH \
-        -url="stdio:$GVPROXY_PATH?listen-stdio=accept&ssh-port=$(get_random_port)&debug=$DEBUG" \
+        -url="stdio:$GVPROXY_PATH?listen-stdio=accept&ssh-port=$PORT&debug=$DEBUG" \
         -iface="$TAP_NAME" \
         -stop-if-exist="" \
         -preexisting=1 \


### PR DESCRIPTION
On Windows, the default VPN port (2222) somehow will been used by PID 4 (also known as System) randomly, that cannot be detected that is been using by command `$(ss -tan4H "sport = $port")`. 

When 2222 port is been using and not detected by `ss`, original strategy will keep using 2222 port, causing unable to start vpn.

This PR implements a change to use random port selection instead default VPN port, or `PORT+=1`

Note:
This update improves the handling of port conflicts, though further work may be needed to fully resolve situations where ports remain undetectable.